### PR TITLE
Fix build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Probability [![Build Status](https://travis-ci.org/BlackBrane/probability.svg?branch=master)](https://travis-ci.org/BlackBrane/probability)
+# Probability [![Build Status](https://travis-ci.org/fieldstrength/probability.svg?branch=master)](https://travis-ci.org/fieldstrength/probability)
 
 _Probabilistic computation in Idris._
 


### PR DESCRIPTION
Sorts out the build status badge for Travis. The URL seemed to be out of date, that's all. It now points at the correct URL.