### PR TITLE
Fix namespacing issue on pow function

### DIFF
--- a/src/Probability/Display.idr
+++ b/src/Probability/Display.idr
@@ -23,8 +23,8 @@ fracPart x = x - intPart x
 
 ||| Raise a double to an arbitrary integral power
 fpow : Double -> Integer -> Double
-fpow f p = if p >= 0 then pow f (cast p)
-                     else 1 / (pow f $ cast $ abs p)
+fpow f p = if p >= 0 then Prelude.pow f (cast p)
+                     else 1 / (Prelude.pow f $ cast $ abs p)
 
 
 ---- Display Bars ----


### PR DESCRIPTION
This PR also contains a fix for [this error](https://github.com/fieldstrength/probability/pull/1#issuecomment-372909195) pointed out by @ivanperez-keera. Tested and now seems to be working great on Idris 1.3.1.