### PR TITLE
Change deprecated use of return to pure

### DIFF
--- a/src/Probability/Monad.idr
+++ b/src/Probability/Monad.idr
@@ -15,7 +15,7 @@ infixl 6 <=<
 
 
 sequ : Monad m => List (a -> m a) -> a -> m a
-sequ = foldl (>=>) return
+sequ = foldl (>=>) pure
 
 
 perform : Monad m => Nat -> (a -> m a) -> a -> m a


### PR DESCRIPTION
The use of the `return` alias has been deprecated in Idris for some time now. This PR changes that to `pure` instead.